### PR TITLE
fix type signature of >>|

### DIFF
--- a/src/PromiseMonad.re
+++ b/src/PromiseMonad.re
@@ -13,5 +13,5 @@ let error = (a: exn) : Js.Promise.t('a) => Js.Promise.reject(a);
 let (>>=) = (m: Js.Promise.t('a), f: 'a => Js.Promise.t('b)) =>
   Js.Promise.then_(f, m);
 
-let (>>|) = (m: Js.Promise.t('a), f: Js.Promise.error => Js.Promise.t('b)) =>
+let (>>|) = (m: Js.Promise.t('a), f: Js.Promise.error => Js.Promise.t('a)) =>
   Js.Promise.catch(f, m);


### PR DESCRIPTION
The signature of `Js.Promise.catch` is `(error -> 'a t) -> 'a t -> 'a t`, so the `'b` in the current type signature of `>>|` will necessarily be constrained to be `'a`, making the signature a bit misleading. Also if it wasn't constrained it would be unsound.