### PR TITLE
Add wrapped bind operator

### DIFF
--- a/src/PromiseMonad.re
+++ b/src/PromiseMonad.re
@@ -13,5 +13,8 @@ let error = (a: exn) : Js.Promise.t('a) => Js.Promise.reject(a);
 let (>>=) = (m: Js.Promise.t('a), f: 'a => Js.Promise.t('b)) =>
   Js.Promise.then_(f, m);
 
+let (>>-) = (m: Js.Promise.t('a), f: 'a => 'b) =>
+  Js.Promise.then_(a => return(f(a)), m);
+
 let (>>|) = (m: Js.Promise.t('a), f: Js.Promise.error => Js.Promise.t('a)) =>
   Js.Promise.catch(f, m);


### PR DESCRIPTION
Adds a wrapped bind operator (not sure if there is a better name for it).
Also not sure if there is another operator better suited for this than `(>>-)`.

This operator wraps the returned value in a `Promise` so that you don’t have to call `return` in your own methods. So you would continue to use `(>>=)` for methods returning Promises and `(>>-)` for methods not already returning Promises.

## Example
Instead of
```reasonml
return(2)
>>= (value => return(value + 2))
>>= (value => return(value + 5))
```

You can do
```reasonml
return(2)
>>- (value => value + 2)
>>- (value => value + 5)
```

Or even better
```reasonml
let add = (a, b) => a + b;
return(2)
>>- add(2)
>>- add(5)
>>= somePromiseMethod
```